### PR TITLE
Set default values in a better way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ installer/ServiceControl-cache
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Particular.Packaging
 
-Note: This package only works with csproj based packaging!
+Note: This package only works with csproj-based packaging!
 
 ## Usage
 
@@ -8,7 +8,7 @@ Add the following package reference to your csproj:
 
 `<PackageReference Include="Particular.Packaging" Version="*" PrivateAssets="All" />`
 
-Add the following required attributes to the csproj:
+The package description defaults to the package id, so add the following project to provide a real description:
 
 ```
   <PropertyGroup>

--- a/src/Particular.Packaging.sln
+++ b/src/Particular.Packaging.sln
@@ -5,6 +5,12 @@ VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Particular.Packaging", "Particular.Packaging\Particular.Packaging.csproj", "{2E869E8B-29E4-42A6-B44A-389F2991E6D4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5B65B796-321E-4BC0-A435-0E0C48071EDD}"
+	ProjectSection(SolutionItems) = preProject
+		Particular.Packaging\Directory.Build.props = Particular.Packaging\Directory.Build.props
+		Particular.Packaging\Directory.Build.targets = Particular.Packaging\Directory.Build.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Particular.Packaging/Directory.Build.props
+++ b/src/Particular.Packaging/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="build/Particular.Packaging.props" />
+</Project>

--- a/src/Particular.Packaging/Directory.Build.targets
+++ b/src/Particular.Packaging/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="build/Particular.Packaging.targets" />
+</Project>

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="build/Particular.Packaging.props" />
-
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
@@ -22,7 +20,5 @@
     <Content Include="build\*" PackagePath="build" />
     <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting" />
   </ItemGroup>
-
-  <Import Project="build/Particular.Packaging.targets" />
 
 </Project>

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -10,6 +10,7 @@
     <Description>NuGet packaging for Particular repositories</Description>
     <PackageProjectUrl>https://particular.net</PackageProjectUrl>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="build/Particular.Packaging.props" />
+
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -10,6 +10,7 @@
     <PackageIconUrl>http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -8,7 +8,6 @@
     <Copyright>© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
     <PackageTags>nservicebus messaging</PackageTags>
     <PackageIconUrl>http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
-    <PackageProjectUrl>https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -1,16 +1,16 @@
 <Project>
 
   <PropertyGroup>
-    <Authors>Particular Software</Authors>
-    <Company>NServiceBus Ltd</Company>
-    <PackageLicenseUrl>http://particular.net/LicenseAgreement</PackageLicenseUrl>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Copyright>© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
-    <PackageTags>nservicebus messaging</PackageTags>
-    <PackageIconUrl>http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
-    <PackageOutputPath>..\..\nugets</PackageOutputPath>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Authors Condition="'$(Authors)' == ''">Particular Software</Authors>
+    <Company Condition="'$(Company)' == ''">NServiceBus Ltd</Company>
+    <PackageLicenseUrl Condition="'$(PackageLicenseUrl)' == ''">http://particular.net/LicenseAgreement</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">true</PackageRequireLicenseAcceptance>
+    <Copyright Condition="'$(Copyright)' == ''">© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
+    <PackageTags Condition="'$(PackageTags)' == ''">nservicebus messaging</PackageTags>
+    <PackageIconUrl Condition="'$(PackageIconUrl)' == ''">http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
+    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">..\..\nugets</PackageOutputPath>
+    <GeneratePackageOnBuild Condition="'$(GeneratePackageOnBuild)' == ''">true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == ''">true</GenerateDocumentationFile>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <PropertyGroup>
+    <Authors>Particular Software</Authors>
+    <Company>NServiceBus Ltd</Company>
+    <PackageLicenseUrl>http://particular.net/LicenseAgreement</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Copyright>© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
+    <PackageTags>nservicebus messaging</PackageTags>
+    <PackageIconUrl>http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
+    <PackageProjectUrl>https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
+    <PackageOutputPath>..\..\nugets</PackageOutputPath>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+</Project>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -1,5 +1,11 @@
 <Project>
 
+  <PropertyGroup>
+    <PackageId Condition="'$(PackageId)' == ''">$(AssemblyName)</PackageId>
+    <Description Condition="'$(Description)' == ''">$(PackageId)</Description>
+    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
+  </PropertyGroup>
+
   <Target Name="IncludePDBsInPackage" Condition="'$(IncludeBuildOutput)' != 'false'">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib/$(TargetFramework)" />

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -1,19 +1,5 @@
 <Project>
 
-  <PropertyGroup>
-    <Authors>Particular Software</Authors>
-    <Company>NServiceBus Ltd</Company>
-    <PackageLicenseUrl Condition="'$(PackageLicenseUrl)' == ''">http://particular.net/LicenseAgreement</PackageLicenseUrl>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Copyright>© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
-    <PackageTags Condition="'$(PackageTags)' == ''">nservicebus messaging</PackageTags>
-    <PackageIconUrl Condition="'$(PackageIconUrl)' == ''">http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
-    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
-    <PackageOutputPath>..\..\nugets</PackageOutputPath>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
-  </PropertyGroup>
-
   <Target Name="IncludePDBsInPackage" Condition="'$(IncludeBuildOutput)' != 'false'">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib/$(TargetFramework)" />

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -6,6 +6,11 @@
     <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IncludeBuildOutput)' == 'false'">
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <DocumentationFile />
+  </PropertyGroup>
+
   <Target Name="IncludePDBsInPackage" Condition="'$(IncludeBuildOutput)' != 'false'">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib/$(TargetFramework)" />

--- a/src/Particular.Packaging/buildMultiTargeting/Particular.Packaging.props
+++ b/src/Particular.Packaging/buildMultiTargeting/Particular.Packaging.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="../build/Particular.Packaging.props" />
+</Project>


### PR DESCRIPTION
@timbussmann This allows for any of the properties to be overridden by just setting the value in the project file, no special properties or conventions to worry about.

I've also added `GenerateDocumentationFile` to the list of properties we set by default, since there's not much point in generating the xml docs file if you aren't going to package it.

I've also added a default Description value (setting it to the package id) so that's not really required now either. I didn't update the README about that yet, though.