### PR TITLE
More updates

### DIFF
--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="None" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="None" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63102-01" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="None" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates to the latest SourceLink package and changes the project TFMs to increase the chance that SourceLink and GitVersion will be correctly referenced in consuming projects.

The TFM change is required because there currently is no way to suppress the TFM-specific dependency groups: https://github.com/NuGet/Home/issues/7154