### PR TITLE
Fixes NU5125 error

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -4,10 +4,6 @@
     <Authors Condition="'$(Authors)' == ''">Particular Software</Authors>
     <Company Condition="'$(Company)' == ''">NServiceBus Ltd</Company>
     <PackageLicenseUrl Condition="'$(PackageLicenseUrl)' == ''">https://particular.net/licenseagreement</PackageLicenseUrl>
-    <!--
-      Suppress a warning about upcoming deprecation of PackageLicenseUrl. When embedding licenses are supported,
-      replace PackageLicenseUrl with PackageLicenseExpression.
-    -->
     <NoWarn>$(NoWarn);NU5125</NoWarn>
     <PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">true</PackageRequireLicenseAcceptance>
     <Copyright Condition="'$(Copyright)' == ''">© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -4,6 +4,11 @@
     <Authors Condition="'$(Authors)' == ''">Particular Software</Authors>
     <Company Condition="'$(Company)' == ''">NServiceBus Ltd</Company>
     <PackageLicenseUrl Condition="'$(PackageLicenseUrl)' == ''">https://particular.net/licenseagreement</PackageLicenseUrl>
+    <!--
+      Suppress a warning about upcoming deprecation of PackageLicenseUrl. When embedding licenses are supported,
+      replace PackageLicenseUrl with PackageLicenseExpression.
+    -->
+    <NoWarn>$(NoWarn);NU5125</NoWarn>
     <PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">true</PackageRequireLicenseAcceptance>
     <Copyright Condition="'$(Copyright)' == ''">© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
     <PackageTags Condition="'$(PackageTags)' == ''">nservicebus messaging</PackageTags>


### PR DESCRIPTION
The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.