### PR TITLE
Use PackageLicenseFile to embed repo's license file

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Authors Condition="'$(Authors)' == ''">Particular Software</Authors>
     <Company Condition="'$(Company)' == ''">NServiceBus Ltd</Company>
-    <PackageLicenseUrl Condition="'$(PackageLicenseUrl)' == ''">https://particular.net/licenseagreement</PackageLicenseUrl>
-    <NoWarn>$(NoWarn);NU5125</NoWarn>
+    <PackageLicenseFile Condition="'$(PackageLicenseFile)' == ''">LICENSE.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">true</PackageRequireLicenseAcceptance>
     <Copyright Condition="'$(Copyright)' == ''">© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
     <PackageTags Condition="'$(PackageTags)' == ''">nservicebus messaging</PackageTags>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -11,4 +11,8 @@
     <DocumentationFile />
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Include="..\..\$(PackageLicenseFile)" Condition="Exists('..\..\$(PackageLicenseFile)')" Pack="true" PackagePath="$(PackageLicenseFile)" Visible="false" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This does make some assumptions in order for it to work correctly:

- The projects that use Particular.Packaging will be in a `src\<project>` file structure
- The license file is located at the root of the repo

It also does assume that the file is named `LICENSE.md`, but that can be overridden if it's not desirable to align the license file to that name.

If any of these assumptions are wrong, then you will see a build error from NuGet saying that the license file wasn't added to the package.

At this point it seems better to assume that these are true, or that they can be made true if they aren't, vs. trying to make this more flexible.