### PR TITLE
Updates

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -7,4 +7,5 @@ branches:
     increment: Minor
     tracks-release-branches: true
   release:
+    increment: Patch
     tag: ''

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.0.1" PrivateAssets="None" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="None" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.0.1" PrivateAssets="None" />
+    <PackageReference Include="GitVersionTask" Version="5.1.2" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="None" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <ParticularPackagingPackagePath>$(MSBuildThisFileDirectory)..\</ParticularPackagingPackagePath>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <Authors Condition="'$(Authors)' == ''">Particular Software</Authors>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -18,4 +18,12 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NuGetMajorVersion>1</NuGetMajorVersion>
+    <NuGetMajorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Major)</NuGetMajorVersion>
+    <NuGetMinorVersion>0</NuGetMinorVersion>
+    <NuGetMinorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Minor)</NuGetMinorVersion>
+    <PackageIconUrl Condition="($(NuGetMajorVersion) &lt; 5 Or ($(NuGetMajorVersion) == 5 And $(NuGetMinorVersion) &lt; 3)) And '$(PackageIconUrl)' == ''">https://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This includes the following changes:

- Update to the RTM Source Link package
- Use `PackageIconUrl` when running against a version of NuGet that doesn't support embedded package icons, for example VS 2017
- Set `IsPackable` to true. We always want to build when this package is references. This removes the need to set this in things like test projects where we build source packages.
- Update to GitVersionTask 5.1.2. We no longer need our custom beta! This should enable building from the `dotnet` command. However, due to a change, we have to update the GitVersion.yml to set `increment: Patch` as part of updating to this new Particular.Packaging version.