### PR TITLE
Tweaks

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
+    <IsPackable Condition="'$(IsPackable)' == ''">true</IsPackable>
     <ParticularPackagingPackagePath>$(MSBuildThisFileDirectory)..\</ParticularPackagingPackagePath>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <Authors Condition="'$(Authors)' == ''">Particular Software</Authors>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -20,11 +20,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NuGetMajorVersion>1</NuGetMajorVersion>
-    <NuGetMajorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Major)</NuGetMajorVersion>
-    <NuGetMinorVersion>0</NuGetMinorVersion>
-    <NuGetMinorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Minor)</NuGetMinorVersion>
-    <PackageIconUrl Condition="($(NuGetMajorVersion) &lt; 5 Or ($(NuGetMajorVersion) == 5 And $(NuGetMinorVersion) &lt; 3)) And '$(PackageIconUrl)' == ''">https://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
+    <ParticularPackagingNuGetMajorVersion>1</ParticularPackagingNuGetMajorVersion>
+    <ParticularPackagingNuGetMajorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Major)</ParticularPackagingNuGetMajorVersion>
+    <ParticularPackagingNuGetMinorVersion>0</ParticularPackagingNuGetMinorVersion>
+    <ParticularPackagingNuGetMinorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Minor)</ParticularPackagingNuGetMinorVersion>
+    <PackageIconUrl Condition="($(ParticularPackagingNuGetMajorVersion) &lt; 5 Or ($(ParticularPackagingNuGetMajorVersion) == 5 And $(ParticularPackagingNuGetMinorVersion) &lt; 3)) And '$(PackageIconUrl)' == ''">https://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR makes the following changes:

- Adds a condition to setting `IsPackable`. This prevents the value from being overwritten if it was set earlier (in a Directory.Build.props for example)
- Adds `ParticularPackaging` to the name of the NuGet version properties. This wasn't causing a problem, but it's just an extra precaution to avoid any potential conflicts and to make it clearer where these properties came from when looking at MSBuild log files.