### PR TITLE
Prevent Source Link from also adding commit hash

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -17,6 +17,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Since GitVersion adds the commit hash to AssemblyInformationVersion, we don't need Source Link to do it as well.

For example, this makes the version string go from:
```
5.2.0-alpha.67+Branch.master.Sha.c3a3daf2e1c0d0a98bd65978d2d7a6ad0aaa48ab.c3a3daf2e1c0d0a98bd65978d2d7a6ad0aaa48ab
```

to 
```
5.2.0-alpha.67+Branch.master.Sha.c3a3daf2e1c0d0a98bd65978d2d7a6ad0aaa48ab
```