### PR TITLE
Don't package the icon twice

### DIFF
--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -23,8 +23,6 @@
     <None Remove="build*\*" />
     <Content Include="build\*" PackagePath="build" />
     <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting" />
-    <None Remove="NServiceBus.png" />
-    <Content Include="NServiceBus.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This prevents the Particular.Packaging package from getting two copies of the NServiceBus.png icon file.

This wasn't a problem for projects that used Particular.Packaging, just this actual package.