### PR TITLE
Add SuppressNuGetPathLengthWarning target

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -22,4 +22,10 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="SuppressNuGetPathLengthWarning" AfterTargets="GetVersion" BeforeTargets="CoreCompile" Condition="'$(TEAMCITY_VERSION)' != ''">
+    <PropertyGroup Condition="'$(GitVersion_BranchName)' != 'master' And $(GitVersion_BranchName.StartsWith('release-')) == false">
+      <NoWarn>$(NoWarn);NU5123</NoWarn>
+    </PropertyGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
This adds a target that will suppress the NU5123 warning only when building a PR on TeamCity.