### PR TITLE
Updates for Source Link

### DIFF
--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.4" PrivateAssets="None" />
+    <PackageReference Include="GitVersionTask" Version="5.3.5" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="None" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -14,6 +14,7 @@
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">..\..\nugets</PackageOutputPath>
     <GeneratePackageOnBuild Condition="'$(GeneratePackageOnBuild)' == ''">true</GeneratePackageOnBuild>
     <GenerateDocumentationFile Condition="'$(GenerateDocumentationFile)' == ''">true</GenerateDocumentationFile>
+    <DebugType Condition="'$(DebugType)' == ''">embedded</DebugType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
This updates to the latest GitVersion, which includes a fix I submitted around files generated by GitVersion not working properly with Source Link.

This also switches to embedded PDBs, which works around the problem of Source Link not working for SDK projects that target .NET Framework or .NET Core 3.1.