### PR TITLE
Disable EOL warning for netcoreapp2.1

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -21,6 +21,10 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <CheckEolTargetFramework Condition="'$(CheckEolTargetFramework)' == ''">false</CheckEolTargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ParticularPackagingNuGetMajorVersion>1</ParticularPackagingNuGetMajorVersion>
     <ParticularPackagingNuGetMajorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Major)</ParticularPackagingNuGetMajorVersion>


### PR DESCRIPTION
This sets the `CheckEolTargetFramework` property to `false` when a project's TFM is `netcoreapp2.1`.

While `netcoreapp2.1` is not triggering the EOL warning yet, it doesn't hurt to go ahead and preemptively add it with the assumption that we'll still be using it in our projects in August.