### PR TITLE
Add targets to block invalid target frameworks

### DIFF
--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetCore.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetCore.targets
@@ -1,0 +1,7 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="NServiceBusBlockNetCore" BeforeTargets="CoreCompile">
+    <Error Text="NServiceBus packages do not support .NET Core versions older than 2.1. Please select a newer version." />
+  </Target>
+
+</Project>

--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetFramework.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetFramework.targets
@@ -1,0 +1,7 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="NServiceBusBlockNetFramework" BeforeTargets="CoreCompile">
+    <Error Text="NServiceBus packages do not support .NET Framework versions older than 4.7.2. Please select a newer version." />
+  </Target>
+
+</Project>

--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandard.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandard.targets
@@ -1,0 +1,7 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="NServiceBusBlockNetStandard" BeforeTargets="CoreCompile">
+    <Error Text="NServiceBus packages do not support .NET Standard. Please select a .NET Framework, .NET Core, or .NET target instead." />
+  </Target>
+
+</Project>

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -10,6 +10,7 @@
     <PackageProjectUrl>https://particular.net</PackageProjectUrl>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <BlockInvalidTargetFrameworks>false</BlockInvalidTargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +23,11 @@
     <None Remove="build*\*" />
     <Content Include="build\*" PackagePath="build" />
     <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="BlockInvalidTargetFrameworks\*" />
+    <Content Include="BlockInvalidTargetFrameworks\*" PackagePath="BlockInvalidTargetFrameworks" />
   </ItemGroup>
 
 </Project>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable Condition="'$(IsPackable)' == ''">true</IsPackable>
     <ParticularPackagingPackagePath>$(MSBuildThisFileDirectory)..\</ParticularPackagingPackagePath>
-    <NoWarn>$(NoWarn);NU5128;NU5105</NoWarn>
+    <NoWarn>$(NoWarn);NU5128;NU5105;NU5109</NoWarn>
     <Authors Condition="'$(Authors)' == ''">Particular Software</Authors>
     <Company Condition="'$(Company)' == ''">NServiceBus Ltd</Company>
     <PackageLicenseFile Condition="'$(PackageLicenseFile)' == ''">LICENSE.md</PackageLicenseFile>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -4,6 +4,7 @@
     <PackageId Condition="'$(PackageId)' == ''">$(AssemblyName)</PackageId>
     <Description Condition="'$(Description)' == ''">$(PackageId)</Description>
     <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
+    <BlockInvalidTargetFrameworksPath>$(ParticularPackagingPackagePath)BlockInvalidTargetFrameworks\</BlockInvalidTargetFrameworksPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IncludeBuildOutput)' == 'false'">
@@ -14,6 +15,13 @@
   <ItemGroup>
     <None Include="..\..\$(PackageLicenseFile)" Condition="Exists('..\..\$(PackageLicenseFile)')" Pack="true" PackagePath="$(PackageLicenseFile)" Visible="false" />
     <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(BlockInvalidTargetFrameworks) != 'false' AND $(PackAsTool) != 'true' AND $(TargetFrameworks.Contains('netstandard')) == 'false'">
+    <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets')" Pack="true" PackagePath="build\netcoreapp2.0\$(PackageId).targets" Visible="false" />
+    <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets')" Pack="true" PackagePath="build\net461\$(PackageId).targets" Visible="false" />
+    <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets')" Pack="true" PackagePath="build\netstandard2.0\$(PackageId).targets" Visible="false" />
+    <None Include="$(BlockInvalidTargetFrameworksPath)\_._" Condition="Exists('$(BlockInvalidTargetFrameworksPath)_._')" Pack="true" PackagePath="build\net472;build\netcoreapp2.1" Visible="false" />
   </ItemGroup>
 
   <Target Name="FixPackageVersion" AfterTargets="GetVersion" BeforeTargets="GenerateNuspec">


### PR DESCRIPTION
With the upcoming change to the frameworks we're targeting in NSB 8, this ensures that if our packages are installed into projects that are using frameworks we don't support but NuGet will allow, we'll always surface an error in the project.