### PR TITLE
More invalid framework blocking

### DIFF
--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetCore.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetCore.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="NServiceBusBlockNetCore" BeforeTargets="CoreCompile">
-    <Error Text="NServiceBus packages do not support .NET Core versions older than 2.1. Please select a newer version." />
+    <Error Text="Package $(MSBuildThisFileName) does not support .NET Core versions older than 2.1. Please use a newer version." />
   </Target>
 
 </Project>

--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetFramework.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetFramework.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="NServiceBusBlockNetFramework" BeforeTargets="CoreCompile">
-    <Error Text="NServiceBus packages do not support .NET Framework versions older than 4.7.2. Please select a newer version." />
+    <Error Text="Package $(MSBuildThisFileName) does not support .NET Framework versions older than 4.7.2. Please use a newer version." />
   </Target>
 
 </Project>

--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandard.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandard.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="NServiceBusBlockNetStandard" BeforeTargets="CoreCompile">
-    <Error Text="NServiceBus packages do not support .NET Standard. Please select a .NET Framework, .NET Core, or .NET target instead." />
+    <Error Text="Package $(MSBuildThisFileName) does not support .NET Standard. Please use .NET Framework, .NET Core, or .NET instead." />
   </Target>
 
 </Project>

--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandardAndNetCore.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandardAndNetCore.targets
@@ -1,0 +1,7 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="BlockNetStandardAndNetCore" BeforeTargets="CoreCompile">
+    <Error Text="Package $(MSBuildThisFileName) does not support .NET Standard or .NET Core. Please use .NET Framework instead." />
+  </Target>
+
+</Project>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -17,7 +17,7 @@
     <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(BlockInvalidTargetFrameworks) != 'false' AND ($(PackageType) == '' OR $(PackageType) == 'Dependency') AND $(TargetFrameworks.Contains('netstandard')) == 'false'">
+  <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(TargetFrameworks.Contains(`netstandard`))' == 'false'">
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets')" Pack="true" PackagePath="build\netcoreapp2.0\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets')" Pack="true" PackagePath="build\net461\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets')" Pack="true" PackagePath="build\netstandard2.0\$(PackageId).targets" Visible="false" />
@@ -44,7 +44,7 @@
   </Target>
 
   <Target Name="SuppressNuGetPathLengthWarning" AfterTargets="GetVersion" BeforeTargets="CoreCompile" Condition="'$(CI)' != '' Or '$(TEAMCITY_VERSION)' != ''">
-    <PropertyGroup Condition="'$(GitVersion_BranchName)' != 'master' And $(GitVersion_BranchName.StartsWith('release-')) == false">
+    <PropertyGroup Condition="'$(GitVersion_BranchName)' != 'master' And '$(GitVersion_BranchName.StartsWith(`release-`))' == 'false'">
       <NoWarn>$(NoWarn);NU5123</NoWarn>
     </PropertyGroup>
   </Target>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -17,7 +17,7 @@
     <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(BlockInvalidTargetFrameworks) != 'false' AND $(PackAsTool) != 'true' AND $(TargetFrameworks.Contains('netstandard')) == 'false'">
+  <ItemGroup Condition="$(BlockInvalidTargetFrameworks) != 'false' AND ($(PackageType) == '' OR $(PackageType) == 'Dependency') AND $(TargetFrameworks.Contains('netstandard')) == 'false'">
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets')" Pack="true" PackagePath="build\netcoreapp2.0\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets')" Pack="true" PackagePath="build\net461\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets')" Pack="true" PackagePath="build\netstandard2.0\$(PackageId).targets" Visible="false" />

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -17,11 +17,17 @@
     <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(TargetFrameworks.Contains(`netstandard`))' == 'false'">
+  <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And '$(IncludeBuildOutput)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(TargetFrameworks)' == 'net472;netcoreapp2.1'">
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets')" Pack="true" PackagePath="build\netcoreapp2.0\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets')" Pack="true" PackagePath="build\net461\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets')" Pack="true" PackagePath="build\netstandard2.0\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)\_._" Condition="Exists('$(BlockInvalidTargetFrameworksPath)_._')" Pack="true" PackagePath="build\net472;build\netcoreapp2.1" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And '$(IncludeBuildOutput)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(IsInnerBuild)' != 'true' And '$(TargetFramework)' == 'net472'">
+    <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets')" Pack="true" PackagePath="build\net461\$(PackageId).targets" Visible="false" />
+    <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetStandardAndNetCore.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetStandardAndNetCore.targets')" Pack="true" PackagePath="build\netstandard2.0\$(PackageId).targets" Visible="false" />
+    <None Include="$(BlockInvalidTargetFrameworksPath)\_._" Condition="Exists('$(BlockInvalidTargetFrameworksPath)_._')" Pack="true" PackagePath="build\net472" Visible="false" />
   </ItemGroup>
 
   <Target Name="FixPackageVersion" AfterTargets="GetVersion" BeforeTargets="GenerateNuspec">


### PR DESCRIPTION
This revises the blocking added in #64 to add the following features;

- The blocking is disabled when the build output is not included in the package, meaning there will be no lib folder
- Dependency packages are now the only type of package that can include blocking. Other types (template, tool) don't need it
- The condition is revised to only ever be enabled for NSB 8 era packages: `net472;netcoreapp2.1`
- Packages that only target `net472` are also correctly handled now.

Some misc cleanup also included.