### PR TITLE
Add support for including source in packages

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -12,6 +12,10 @@
     <DocumentationFile />
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IncludeSourceFilesInPackage)' == 'true'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddSourceFilesToPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\..\$(PackageLicenseFile)" Condition="Exists('..\..\$(PackageLicenseFile)')" Pack="true" PackagePath="$(PackageLicenseFile)" Visible="false" />
     <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
@@ -46,6 +50,17 @@
       </_ProjectReferencesWithVersionRanges>
       <_ProjectReferencesWithVersions Remove="@(_ProjectReferencesWithVersions)" />
       <_ProjectReferencesWithVersions Include="@(_ProjectReferencesWithVersionRanges)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddSourceFilesToPackage">
+    <ItemGroup>
+      <_File Remove="@(_File)"/>
+      <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="contentFiles/cs/$(TargetFramework)/$(MSBuildProjectName.Replace('NServiceBus', 'NSB'))" BuildAction="Compile" />
+      <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="content/$(TargetFramework)/App_Packages/$(MSBuildProjectName.Replace('NServiceBus', 'NSB')).$(PackageVersion)" BuildAction="Compile" Condition="'$(TargetFramework.Contains(`netcoreapp`))' == 'false' And '$(TargetFramework.Contains(`netstandard`))' == 'false'" />
+      <_File Remove="$(MSBuildProjectDirectory)\obj\**\*.cs" />
+      <_File Remove="@(RemoveSourceFileFromPackage -> '%(FullPath)')" />
+      <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This lets a project include source in the package by setting `IncludeSourceFilesInPackage` to `true` instead of needing [more complicated stuff](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj#L34-L44) in each project file.