### PR TITLE
Use GitVersion_MajorMinorPatch instead of PackageVersion

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -57,7 +57,7 @@
     <ItemGroup>
       <_File Remove="@(_File)"/>
       <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="contentFiles/cs/$(TargetFramework)/$(MSBuildProjectName.Replace('NServiceBus', 'NSB'))" BuildAction="Compile" />
-      <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="content/$(TargetFramework)/App_Packages/$(MSBuildProjectName.Replace('NServiceBus', 'NSB')).$(PackageVersion)" BuildAction="Compile" Condition="'$(TargetFramework.Contains(`netcoreapp`))' == 'false' And '$(TargetFramework.Contains(`netstandard`))' == 'false'" />
+      <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="content/$(TargetFramework)/App_Packages/$(MSBuildProjectName.Replace('NServiceBus', 'NSB')).$(GitVersion_MajorMinorPatch)" BuildAction="Compile" Condition="'$(TargetFramework.Contains(`netcoreapp`))' == 'false' And '$(TargetFramework.Contains(`netstandard`))' == 'false'" />
       <_File Remove="$(MSBuildProjectDirectory)\obj\**\*.cs" />
       <_File Remove="@(RemoveSourceFileFromPackage -> '%(FullPath)')" />
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="particular myget.org" value="https://www.myget.org/F/particular/api/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
`PackageVersion` is making the paths too long for the legacy "Content" section of the source package since that includes the full prerelease version.
