### PR TITLE
Update GitVersion to 5.8.1 which fixes the tag version determination problem

### DIFF
--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.11" PrivateAssets="None" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.8.1" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="None" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
See for example https://github.com/Particular/NServiceBus.Gateway.RavenDB/actions/runs/1515607518

Previously we always got 2.0.0-tag-1.1.0 instead of 1.1.0

See also https://github.com/Particular/NServiceBus.Gateway.RavenDB/commit/6943d246eecb51e961dac48c3162a12474d029d3