### PR TITLE
Cleanup and fixes

### DIFF
--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetCore.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetCore.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="NServiceBusBlockNetCore" BeforeTargets="CoreCompile">
-    <Error Text="Package $(MSBuildThisFileName) does not support .NET Core versions older than 2.1. Please use a newer version." />
+    <Error Text="Package $(MSBuildThisFileName) does not support .NET Core versions older than 3.1. Please use a newer version." />
   </Target>
 
 </Project>

--- a/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandardAndNetCore.targets
+++ b/src/Particular.Packaging/BlockInvalidTargetFrameworks/BlockNetStandardAndNetCore.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="BlockNetStandardAndNetCore" BeforeTargets="CoreCompile">
-    <Error Text="Package $(MSBuildThisFileName) does not support .NET Standard or .NET Core. Please use .NET Framework instead." />
+    <Error Text="Package $(MSBuildThisFileName) does not support .NET Standard, .NET Core, or .NET. Please use .NET Framework instead." />
   </Target>
 
 </Project>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -21,12 +21,4 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <ParticularPackagingNuGetMajorVersion>1</ParticularPackagingNuGetMajorVersion>
-    <ParticularPackagingNuGetMajorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Major)</ParticularPackagingNuGetMajorVersion>
-    <ParticularPackagingNuGetMinorVersion>0</ParticularPackagingNuGetMinorVersion>
-    <ParticularPackagingNuGetMinorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Minor)</ParticularPackagingNuGetMinorVersion>
-    <PackageIconUrl Condition="($(ParticularPackagingNuGetMajorVersion) &lt; 5 Or ($(ParticularPackagingNuGetMajorVersion) == 5 And $(ParticularPackagingNuGetMinorVersion) &lt; 3)) And '$(PackageIconUrl)' == ''">https://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
-  </PropertyGroup>
-
 </Project>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -21,10 +21,6 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <CheckEolTargetFramework Condition="'$(CheckEolTargetFramework)' == ''">false</CheckEolTargetFramework>
-  </PropertyGroup>
-
   <PropertyGroup>
     <ParticularPackagingNuGetMajorVersion>1</ParticularPackagingNuGetMajorVersion>
     <ParticularPackagingNuGetMajorVersion Condition="'$(NuGetToolVersion)' != ''">$([System.Version]::Parse($(NuGetToolVersion)).Major)</ParticularPackagingNuGetMajorVersion>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -21,11 +21,11 @@
     <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And '$(IncludeBuildOutput)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(TargetFrameworks)' == 'net472;netcoreapp2.1'">
+  <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And '$(IncludeBuildOutput)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(TargetFrameworks)' == 'net472;netcoreapp3.1'">
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetCore.targets')" Pack="true" PackagePath="build\netcoreapp2.0\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetFramework.targets')" Pack="true" PackagePath="build\net461\$(PackageId).targets" Visible="false" />
     <None Include="$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets" Condition="Exists('$(BlockInvalidTargetFrameworksPath)BlockNetStandard.targets')" Pack="true" PackagePath="build\netstandard2.0\$(PackageId).targets" Visible="false" />
-    <None Include="$(BlockInvalidTargetFrameworksPath)\_._" Condition="Exists('$(BlockInvalidTargetFrameworksPath)_._')" Pack="true" PackagePath="build\net472;build\netcoreapp2.1" Visible="false" />
+    <None Include="$(BlockInvalidTargetFrameworksPath)\_._" Condition="Exists('$(BlockInvalidTargetFrameworksPath)_._')" Pack="true" PackagePath="build\net472;build\netcoreapp3.1" Visible="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And '$(IncludeBuildOutput)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(IsInnerBuild)' != 'true' And '$(TargetFramework)' == 'net472'">

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -57,9 +57,9 @@
     <ItemGroup>
       <_File Remove="@(_File)"/>
       <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="contentFiles/cs/$(TargetFramework)/$(MSBuildProjectName.Replace('NServiceBus', 'NSB'))" BuildAction="Compile" />
-      <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="content/$(TargetFramework)/App_Packages/$(MSBuildProjectName.Replace('NServiceBus', 'NSB')).$(GitVersion_MajorMinorPatch)" Condition="'$(TargetFramework.Contains(`netcoreapp`))' == 'false' And '$(TargetFramework.Contains(`netstandard`))' == 'false'" />
+      <_File Include="$(MSBuildProjectDirectory)\**\*.cs" TargetDir="content/$(TargetFramework)/App_Packages/$(MSBuildProjectName.Replace('NServiceBus', 'NSB')).$(GitVersion_MajorMinorPatch)" Condition="'$(TargetFramework.Contains(`.`))' == 'false'" />
       <_File Include="@(AddSourceFileToPackage)" TargetDir="contentFiles/cs/$(TargetFramework)/$(MSBuildProjectName.Replace('NServiceBus', 'NSB'))" BuildAction="Compile" />
-      <_File Include="@(AddSourceFileToPackage)" TargetDir="content/$(TargetFramework)/App_Packages/$(MSBuildProjectName.Replace('NServiceBus', 'NSB')).$(GitVersion_MajorMinorPatch)" Condition="'$(TargetFramework.Contains(`netcoreapp`))' == 'false' And '$(TargetFramework.Contains(`netstandard`))' == 'false'" />
+      <_File Include="@(AddSourceFileToPackage)" TargetDir="content/$(TargetFramework)/App_Packages/$(MSBuildProjectName.Replace('NServiceBus', 'NSB')).$(GitVersion_MajorMinorPatch)" Condition="'$(TargetFramework.Contains(`.`))' == 'false'" />
       <_File Remove="$(MSBuildProjectDirectory)\obj\**\*.cs" />
       <_File Remove="@(RemoveSourceFileFromPackage -> '%(FullPath)')" />
       <TfmSpecificPackageFile Include="@(_File)" PackagePath="%(_File.TargetDir)/%(_File.RecursiveDir)%(_File.FileName)%(_File.Extension)"/>


### PR DESCRIPTION
This PR includes the following changes:
- Now that we've removed `netcoreapp2.1` TFMs, we no longer want to suppress the warning about it being EOL, so that has been removed. (It also didn't seem to work!?)
- We no longer care about old VS versions for building our repos (2017 and non-updated 2019) so I have removed the workaround for setting `PackageIconUrl` for those versions
- The invalid framework blocking stuff needed to be updated to handle that we are targeting `netcoreapp3.1` instead of `netcoreapp2.1`
- The source packaging feature was not handling the newer .NET TFMs properly, so that has been fixed