### PR TITLE
Run WriteMinVerProperties in outer build only

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -66,7 +66,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="WriteMinVerProperties" AfterTargets="MinVer" Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(WriteMinVerProperties)' != 'false'">
+  <Target Name="WriteMinVerProperties" DependsOnTargets="MinVer" AfterTargets="Build" Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(WriteMinVerProperties)' != 'false' And '$(IsInnerBuild)' != 'true'">
     <ItemGroup>
       <MinVerProperties Include="MinVerVersion=$(MinVerVersion)" />
       <MinVerProperties Include="MinVerMajor=$(MinVerMajor)" />


### PR DESCRIPTION
This ensures that the `WriteMinVerProperties` target needed to make the properties be available for use in later CI steps only runs once per project build.

Before, the target would run once per target framework, so it could potentially conflict with trying to write to the `GITHUB_ENV` file at the same time.