### PR TITLE
Updates for a new major version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             name: Windows
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: Linux
       fail-fast: false
     steps:
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
-    runs-on: windows-2019 # Code signing requirement https://github.com/NuGet/Home/issues/7939
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -17,23 +17,16 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build src --configuration Release
-      - name: Install NuGetKeyVaultSignTool
-        run: dotnet tool install --global NuGetKeyVaultSignTool
-      - name: Sign NuGet Packages
-        run: |
-          NuGetKeyVaultSignTool sign nugets\*.nupkg `
-          --file-digest sha256 `
-          --timestamp-rfc3161 http://timestamp.digicert.com `
-          --timestamp-digest sha256 `
-          --azure-key-vault-url https://particularcodesigning.vault.azure.net `
-          --azure-key-vault-client-id ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }} `
-          --azure-key-vault-tenant-id ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }} `
-          --azure-key-vault-client-secret ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }} `
-          --azure-key-vault-certificate ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
-        shell: pwsh
+      - name: Sign NuGet packages
+        uses: Particular/sign-nuget-packages-action@v1.0.0
+        with:
+          client-id: ${{ secrets.AZURE_KEY_VAULT_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_KEY_VAULT_TENANT_ID }}
+          client-secret: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
+          certificate-name: ${{ secrets.AZURE_KEY_VAULT_CERTIFICATE_NAME }}
       - name: Publish artifacts
         uses: actions/upload-artifact@v3.1.3
         with:

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>2.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>
 

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="None" />
-    <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="None" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="None" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -8,7 +8,7 @@
     <Company Condition="'$(Company)' == ''">NServiceBus Ltd</Company>
     <PackageLicenseFile Condition="'$(PackageLicenseFile)' == ''">LICENSE.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">true</PackageRequireLicenseAcceptance>
-    <Copyright Condition="'$(Copyright)' == ''">© 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus Ltd. All rights reserved.</Copyright>
+    <Copyright Condition="'$(Copyright)' == ''">© NServiceBus Ltd. All rights reserved.</Copyright>
     <PackageTags Condition="'$(PackageTags)' == ''">nservicebus messaging</PackageTags>
     <PackageIcon Condition="'$(PackageIcon)' == ''">NServiceBus.png</PackageIcon>
     <PackageReadmeFile Condition="'$(PackageReadmeFile)' == ''">Package-README.md</PackageReadmeFile>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -17,10 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\$(PackageLicenseFile)" Condition="'$(PackageLicenseFile)' != '' And Exists('..\..\$(PackageLicenseFile)')" Pack="true" PackagePath="$(PackageLicenseFile)" Visible="false" />
-    <None Include="..\..\$(PackageReadmeFile)" Condition="'$(PackageReadmeFile)' != '' And Exists('..\..\$(PackageReadmeFile)')" Pack="true" PackagePath="$(PackageReadmeFile)" Visible="false" />
+    <None Include="..\..\$(PackageLicenseFile)" Condition="'$(PackageLicenseFile)' != '' And Exists('..\..\$(PackageLicenseFile)')" Pack="true" PackagePath="" Visible="false" />
+    <None Include="..\..\$(PackageReadmeFile)" Condition="'$(PackageReadmeFile)' != '' And Exists('..\..\$(PackageReadmeFile)')" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\..\THIRD-PARTY-NOTICES.txt" Condition="Exists('..\..\THIRD-PARTY-NOTICES.txt')" Pack="true" PackagePath="" Visible="false" />
-    <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="'$(PackageIcon)' != '' And Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
+    <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="'$(PackageIcon)' != '' And Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BlockInvalidTargetFrameworks)' != 'false' And '$(IncludeBuildOutput)' != 'false' And ('$(PackageType)' == '' Or '$(PackageType)' == 'Dependency') And '$(TargetFrameworks)' == 'net472;net6.0'">

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -79,4 +79,10 @@
     <WriteLinesToFile File="$(GITHUB_ENV)" Lines="@(MinVerProperties)" />
   </Target>
 
+  <Target Name="WorkaroundForTestHostBeingAddedAsContent" BeforeTargets="_GetPackageFiles" Condition="'$(IsTestProject)' == 'true'">
+    <ItemGroup>
+      <Content Update="**\testhost.*" Pack="false" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -19,6 +19,7 @@
   <ItemGroup>
     <None Include="..\..\$(PackageLicenseFile)" Condition="'$(PackageLicenseFile)' != '' And Exists('..\..\$(PackageLicenseFile)')" Pack="true" PackagePath="$(PackageLicenseFile)" Visible="false" />
     <None Include="..\..\$(PackageReadmeFile)" Condition="'$(PackageReadmeFile)' != '' And Exists('..\..\$(PackageReadmeFile)')" Pack="true" PackagePath="$(PackageReadmeFile)" Visible="false" />
+    <None Include="..\..\THIRD-PARTY-NOTICES.txt" Condition="Exists('..\..\THIRD-PARTY-NOTICES.txt')" Pack="true" PackagePath="" Visible="false" />
     <None Include="$(ParticularPackagingPackagePath)$(PackageIcon)" Condition="'$(PackageIcon)' != '' And Exists('$(ParticularPackagingPackagePath)$(PackageIcon)')" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
   </ItemGroup>
 

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -86,4 +86,8 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="VerifySdkVersion" BeforeTargets="CoreCompile" Condition="$([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '8.0.100'))">
+    <Error Text="Particular.Packaging requires .NET SDK 8.0.100 or greater. Version being used: $(NETCoreSdkVersion)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
It's time for another major version of Particular.Packaging. The primary change here is that we don't need to include the SourceLink package because it's now built in to the .NET 8 SDK.

That does mean that any repo branches that get updated to the new version of Packaging but don't aren't using the .NET 8 SDK in workflows would lose SourceLink info. ~I suppose I could try and add something to detect this, but probably not worth it?~ EDIT: I went ahead and added a target to check for this.

I also went ahead and bumped up the TFM of the project, which really was only there to ensure that the MinVer and SourceLink dependencies on the package would get included in all referencing projects, but it should be safe at this point to assume that all repos have TFMs that are compatible with `netstandard2.0`.

Other minor changes:
- I removed the copyright date calculation because I noticed that Microsoft doesn't bother with anything like that in their packages. If they don't do it, then I can't see why we need it.
- I added a workaround for test projects that also produce a package, so we can clean up the workarounds from those projects, for example: [NServiceBus.AcceptanceTests](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj#L32-L36)
- Also following Microsoft's pattern, if a `THIRD-PARTY-NOTICES.txt` exists in the repo root, it will be included in the package. I've already done this for [Particular.Msmq](https://github.com/Particular/Particular.Msmq/blob/main/THIRD-PARTY-NOTICES.txt), and we should move to this in all repos where we are including other codes that has licenses we need to declare.