### PR TITLE
Add MSBuild tasks

### DIFF
--- a/src/Particular.Packaging.Tasks/Directory.Build.props
+++ b/src/Particular.Packaging.Tasks/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" Condition="Exists($([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..)))" />
+  <Import Project="../Particular.Packaging/build/Particular.Packaging.props" />
+</Project>

--- a/src/Particular.Packaging.Tasks/Directory.Build.targets
+++ b/src/Particular.Packaging.Tasks/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" Condition="Exists($([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..)))" />
+  <Import Project="../Particular.Packaging/build/Particular.Packaging.targets" />
+</Project>

--- a/src/Particular.Packaging.Tasks/GetDuplicateFiles.cs
+++ b/src/Particular.Packaging.Tasks/GetDuplicateFiles.cs
@@ -1,0 +1,58 @@
+namespace Particular.Packaging.Tasks;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class GetDuplicateFiles : Task
+{
+    [Required]
+    public string BasePath { get; set; } = string.Empty;
+
+    [Required]
+    public ITaskItem[] Paths { get; set; } = [];
+
+    [Output]
+    public ITaskItem[]? DuplicateFiles { get; private set; } = [];
+
+    public override bool Execute()
+    {
+        BasePath = Path.GetFullPath(BasePath);
+        HashSet<(string, long)>? duplicates = null;
+
+        foreach (var path in Paths)
+        {
+            var files = EnumerateFiles(Path.Combine(BasePath, path.ItemSpec));
+            duplicates ??= files;
+
+            duplicates.IntersectWith(files);
+        }
+
+        if (duplicates is not null)
+        {
+            var results = new List<ITaskItem>(duplicates.Count);
+
+            foreach (var (fileName, _) in duplicates)
+            {
+                results.Add(new TaskItem(fileName));
+            }
+
+            DuplicateFiles = results.ToArray();
+        }
+
+        return true;
+    }
+
+    static HashSet<(string FileName, long Length)> EnumerateFiles(string path)
+    {
+        HashSet<(string, long)> files = [];
+
+        foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+        {
+            var fileInfo = new FileInfo(file);
+            var fileName = fileInfo.FullName.Substring(path.Length + 1);
+            files.Add((fileName, fileInfo.Length));
+        }
+
+        return files;
+    }
+}

--- a/src/Particular.Packaging.Tasks/Particular.Packaging.Tasks.csproj
+++ b/src/Particular.Packaging.Tasks/Particular.Packaging.Tasks.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.9.5" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/src/Particular.Packaging.Tasks/ZipFiles.cs
+++ b/src/Particular.Packaging.Tasks/ZipFiles.cs
@@ -1,0 +1,37 @@
+﻿namespace Particular.Packaging.Tasks;
+
+using System.IO.Compression;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class ZipFiles : Task
+{
+    [Required]
+    public string BasePath { get; set; } = string.Empty;
+
+    [Required]
+    public ITaskItem[] Files { get; set; } = [];
+
+    public ITaskItem[] ExcludedFiles { get; set; } = [];
+
+    [Required]
+    public string DestinationFile { get; set; } = string.Empty;
+
+    public override bool Execute()
+    {
+        using var fileStream = new FileStream(DestinationFile, FileMode.Create);
+        using var zipArchive = new ZipArchive(fileStream, ZipArchiveMode.Create);
+
+        foreach (var file in Files)
+        {
+            var entryName = file.ItemSpec.Substring(BasePath.Length + 1);
+
+            if (!ExcludedFiles.Any(t => t.ItemSpec == entryName))
+            {
+                zipArchive.CreateEntryFromFile(file.ItemSpec, entryName, CompressionLevel.Optimal);
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Particular.Packaging.sln
+++ b/src/Particular.Packaging.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Custom.Build.props = Custom.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Particular.Packaging.Tasks", "Particular.Packaging.Tasks\Particular.Packaging.Tasks.csproj", "{744BF34C-4DF9-41E1-813D-EA1BF2E6D2A4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{2E869E8B-29E4-42A6-B44A-389F2991E6D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E869E8B-29E4-42A6-B44A-389F2991E6D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E869E8B-29E4-42A6-B44A-389F2991E6D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{744BF34C-4DF9-41E1-813D-EA1BF2E6D2A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{744BF34C-4DF9-41E1-813D-EA1BF2E6D2A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{744BF34C-4DF9-41E1-813D-EA1BF2E6D2A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{744BF34C-4DF9-41E1-813D-EA1BF2E6D2A4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Particular.Packaging.Tasks\Particular.Packaging.Tasks.csproj" ReferenceOutputAssembly="false" Private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="None" />
   </ItemGroup>
 
@@ -26,6 +30,10 @@
   <ItemGroup>
     <None Remove="BlockInvalidTargetFrameworks\*" />
     <Content Include="BlockInvalidTargetFrameworks\*" PackagePath="BlockInvalidTargetFrameworks" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Particular.Packaging.Tasks\bin\$(Configuration)\netstandard2.0\Particular.Packaging.Tasks.dll" Pack="true" PackagePath="build\tasks" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -19,6 +19,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ParticularPackagingTasksPath>$(MSBuildThisFileDirectory)tasks\Particular.Packaging.Tasks.dll</ParticularPackagingTasksPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds two MSBuild tasks, `GetDuplicateFiles` and `ZipFiles`, which can then be used by any project as part of its build.