### PR TITLE
Prevent WriteMinVerProperties target from failing the build

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -77,7 +77,7 @@
       <MinVerProperties Include="MinVerPreRelease=$(MinVerPreRelease)" />
       <MinVerProperties Include="MinVerBuildMetadata=$(MinVerBuildMetadata)" />
     </ItemGroup>
-    <WriteLinesToFile File="$(GITHUB_ENV)" Lines="@(MinVerProperties)" />
+    <WriteLinesToFile File="$(GITHUB_ENV)" Lines="@(MinVerProperties)" ContinueOnError="WarnAndContinue" />
   </Target>
 
   <Target Name="WorkaroundForTestHostBeingAddedAsContent" BeforeTargets="_GetPackageFiles" Condition="'$(IsTestProject)' == 'true'">


### PR DESCRIPTION
The `WriteLinesToFile` task in the `WriteMinVerProperties` target can fail during a build if another project is writing to the file at the same time. If this happens, it should be fine since that means the information is being written to the file and we don't need it to be in there twice.

Setting `ContinueOnError="WarnAndContinue"` on the task should let this failure be de-escalated to a warning and let the build continue. This should be true regardless of the `TreatWarningsAsErrors` setting.

