### PR TITLE
Ensure GITHUB_ENV has a value before running target

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -68,7 +68,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="WriteMinVerProperties" DependsOnTargets="MinVer" AfterTargets="Build" Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(WriteMinVerProperties)' != 'false' And '$(IsInnerBuild)' != 'true'">
+  <Target Name="WriteMinVerProperties" DependsOnTargets="MinVer" AfterTargets="Build" Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(GITHUB_ENV)' != '' And '$(WriteMinVerProperties)' != 'false' And '$(IsInnerBuild)' != 'true'">
     <ItemGroup>
       <MinVerProperties Include="MinVerVersion=$(MinVerVersion)" />
       <MinVerProperties Include="MinVerMajor=$(MinVerMajor)" />


### PR DESCRIPTION
Looks like Dependabot is doing something weird where `GITHUB_ENV` doesn't have value set during its action runs, so I've added a condition to ensure that the `WriteMinVerProperties` target gets skipped when that is true.

