### PR TITLE
Disable warning for packaging non-packable projects

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -20,6 +20,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ParticularPackagingTasksPath>$(MSBuildThisFileDirectory)tasks\Particular.Packaging.Tasks.dll</ParticularPackagingTasksPath>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The Microsoft.NET.Sdk.Web project SDK enables `WarnOnPackingNonPackableProject` for some reason. 

That means if a web project is in a solution where Particular.Packaging is referenced but `IsPackable` has been set to `false` for the project, it will generate the following warning:
```
 Warning  : This project cannot be packaged because packaging has been disabled. Add <IsPackable>true</IsPackable> to the project file to enable producing a package from this project.
```

Setting `WarnOnPackingNonPackableProject` to `false` here ensures the warning is suppressed.