### PR TITLE
Add SBOM generation

### DIFF
--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.0.2" PrivateAssets="None" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="None" />
   </ItemGroup>
 

--- a/src/Particular.Packaging/build/Particular.Packaging.props
+++ b/src/Particular.Packaging/build/Particular.Packaging.props
@@ -21,6 +21,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ParticularPackagingTasksPath>$(MSBuildThisFileDirectory)tasks\Particular.Packaging.Tasks.dll</ParticularPackagingTasksPath>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <GenerateSBOM Condition="'$(GenerateSBOM)' == '' And '$(Configuration)' == 'Release'">true</GenerateSBOM>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds the Microsoft.Sbom.Targets package to include SBOMs in NuGet packages. The SBOM is only generated for `Release` builds to not add build time overhead while developing.