### PR TITLE
Fix package version in SBOM

### DIFF
--- a/src/Particular.Packaging/Particular.Packaging.csproj
+++ b/src/Particular.Packaging/Particular.Packaging.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.0.2" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.0.3" PrivateAssets="None" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="None" />
   </ItemGroup>
 

--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -80,6 +80,12 @@
     <WriteLinesToFile File="$(GITHUB_ENV)" Lines="@(MinVerProperties)" ContinueOnError="WarnAndContinue" />
   </Target>
 
+  <Target Name="UpdateSbomGenerationPackageVersion" AfterTargets="MinVer">
+    <PropertyGroup>
+      <SbomGenerationPackageVersion>$(MinVerVersion)</SbomGenerationPackageVersion>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="WorkaroundForTestHostBeingAddedAsContent" BeforeTargets="_GetPackageFiles" Condition="'$(IsTestProject)' == 'true'">
     <ItemGroup>
       <Content Update="**\testhost.*" Pack="false" />


### PR DESCRIPTION
Follow-up to #239 

The SBOM tool wasn't getting the correct package version passed in, so this PR adds a target to ensure the value gets set properly.