### PR TITLE
Add target to setup release notes URL in the nuspec file

### DIFF
--- a/src/Particular.Packaging/build/Particular.Packaging.targets
+++ b/src/Particular.Packaging/build/Particular.Packaging.targets
@@ -80,11 +80,11 @@
     <WriteLinesToFile File="$(GITHUB_ENV)" Lines="@(MinVerProperties)" ContinueOnError="WarnAndContinue" />
   </Target>
 
-  <Target Name="AddReleaseNotesLink" AfterTargets="InitializeSourceControlInformationFromSourceControlManager">
-    <PropertyGroup>      
-      <ReleaseNotesSourceControlURL Condition="$(ScmRepositoryUrl.EndsWith('.git'))">$(ScmRepositoryUrl.SubString(0, $(ScmRepositoryUrl.LastIndexOf(".git"))))</ReleaseNotesSourceControlURL>
-      <ReleaseNotesSourceControlURL Condition="!$(ScmRepositoryUrl.EndsWith('.git'))">$(ScmRepositoryUrl)</ReleaseNotesSourceControlURL>
-      <PackageReleaseNotes>$(ReleaseNotesSourceControlURL)/releases/$(MinVerVersion)</PackageReleaseNotes>
+  <Target Name="AddReleaseNotesLink" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <ReleaseNotesSourceControlUrl>$(ScmRepositoryUrl)</ReleaseNotesSourceControlUrl>
+      <ReleaseNotesSourceControlUrl Condition="$(ReleaseNotesSourceControlUrl.EndsWith('.git'))">$(ReleaseNotesSourceControlUrl.SubString(0, $(ReleaseNotesSourceControlUrl.LastIndexOf(".git"))))</ReleaseNotesSourceControlUrl>
+      <PackageReleaseNotes>$(ReleaseNotesSourceControlUrl)/releases/tag/$(MinVerVersion)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
This change adds the `<releaseNotes>` tag to the `.nuspec` file in the release package. The tag will include a link to the release notes in the GitHub repository. This will result in a clickable link in the Release Notes tab on the NuGet.org page for each package that uses Particular.Packaging.

The URL to the release notes is generated using the source control repository URL generated by source link, a hardcoded `/releases/`, and then the version generated by MinVer during the build process.  

It is assumed GitHub will continue using the `/releases` URL convention for the foreseeable future.

![image](https://github.com/user-attachments/assets/e2db126b-4f69-4939-8c4b-f2225f45ac10)
 